### PR TITLE
Vagrant setup to enable testing of various roles and targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
+.vagrant
+# Not sure how relevant the below entries are still
 *.retry
 *.rsc
-locales/memphis/private_configs/extensions.conf.j2
-locales/memphis/private_configs/iax.conf.j2
-locales/memphis/private_configs/sip.conf.j2
-locales/memphis/private_configs/voicemail.conf.j2

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# HamWAN Infrastructure Configs
+
+## Developer Workstation Setup (Fedora)
+```
+sudo dnf -y install vagrant-libvirt rubygem-rexml @virtualization
+sudo systemctl enable --now libvirtd
+sudo usermod --append --groups libvirt `whoami`
+vagrant up --no-parallel
+```
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,63 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  VMs = [
+    {
+      "name" => 'test.missing.users',
+      "ip" => '192.168.222.10',
+      "custom" => '
+        groupadd hamadmin
+        groupadd ham
+        useradd eo -G hamadmin
+        useradd monitoring -G ham
+      ',
+    },
+    {
+      "name" => 'test.extra.users',
+      "ip" => '192.168.222.11',
+      "custom" => '
+        groupadd hamadmin
+        groupadd ham
+        useradd eo -G hamadmin
+        useradd haxxxor -G hamadmin
+        useradd monitoring -G ham
+        useradd soyboy -G ham
+      ',
+    },
+  ]
+ 
+  VMs.each do |vm|
+    config.vm.define vm["name"] do |node|
+      node.vm.box = "generic/fedora37"
+      node.vm.hostname = vm["name"]
+      node.vm.network "private_network", ip: vm["ip"], auto_config: false
+      node.vm.provider :libvirt do |libvirt|
+        libvirt.qemu_use_session = false
+      end
+      #node.ssh.port = 222
+      #node.ssh.guest_port = 222
+      node.vm.provision "shell", inline: <<-SHELL
+        semanage port -a -t ssh_port_t -p tcp 222
+        firewall-cmd --add-port=222/tcp --permanent
+        firewall-cmd --reload
+        IP_eth0=`ip -f inet addr show eth0 | grep -Po 'inet \\K[\\d.]+'`
+        IP_eth1=#{vm["ip"]}
+        CONNECTION_eth1=`nmcli dev show eth1 | grep "GENERAL.CONNECTION" | sed -e 's/.*: *//'`
+        nmcli con mod "${CONNECTION_eth1}" ipv4.method manual ipv4.addresses ${IP_eth1}/24
+        nmcli con up "${CONNECTION_eth1}"
+        echo "ListenAddress ${IP_eth0}:22" >> /etc/ssh/sshd_config
+        echo "ListenAddress ${IP_eth1}:222" >> /etc/ssh/sshd_config
+        systemctl restart sshd
+        #{vm["custom"]}
+      SHELL
+    end
+  end
+end


### PR DESCRIPTION
This automation has the power to add and delete all users within seconds. It must be tested against non-prod.  This Vagrant setup will allow various OSes to be mocked up and tested against, including RouterOS.  All locally, without the burden of maintaining integration test infrastructure.