### PR TITLE
Introduce group management scope

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,7 @@ Vagrant.configure("2") do |config|
       "ip" => '192.168.222.12',
       "custom" => '
         groupadd hamwan
+        echo -e "hamwan\nhamadmin\nham" > /etc/group_managed_scope
         useradd eo -G hamwan
         mkdir -m 0700 ~eo/.ssh
         echo "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAILkuO+XcdH7AVa326qU6Sw8Ly4Ju3mszmU4ydL6LqHhO eo@ansible.bartk.us" > ~eo/.ssh/authorized_keys

--- a/roles/users/molecule/default/verify.yml
+++ b/roles/users/molecule/default/verify.yml
@@ -64,3 +64,5 @@
     ansible.builtin.copy:
       dest: /etc/group_managed_scope
       content: "hamadmin\nham\n"
+    register: ret
+    failed_when: ret.changed

--- a/roles/users/molecule/default/verify.yml
+++ b/roles/users/molecule/default/verify.yml
@@ -47,3 +47,20 @@
       state: present
     register: ret
     failed_when: ret.changed
+
+  - name: Verify unwanted groups are absent
+    check_mode: true
+    ansible.builtin.group:
+      name: "{{ item }}"
+      state: absent
+    register: ret
+    failed_when: ret.changed
+    loop:
+      - hamwan
+    when: inventory_hostname == 'test.group.change'
+
+  - name: Verify group management scope contains only wanted groups
+    check_mode: true
+    ansible.builtin.copy:
+      dest: /etc/group_managed_scope
+      content: "hamadmin\nham\n"

--- a/roles/users/molecule/default/verify.yml
+++ b/roles/users/molecule/default/verify.yml
@@ -59,6 +59,17 @@
       - hamwan
     when: inventory_hostname == 'test.group.change'
 
+  - name: Verify unwanted sudoers configs are absent
+    check_mode: true
+    ansible.builtin.file:
+      name: "{{ item }}"
+      state: absent
+    register: ret
+    failed_when: ret.changed
+    loop:
+      - /etc/sudoers.d/hamwan
+    when: inventory_hostname == 'test.group.change'
+
   - name: Verify group management scope contains only wanted groups
     check_mode: true
     ansible.builtin.copy:

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -203,6 +203,45 @@
   when: test_flaky_network
   failed_when: false
 
+- name: Check for old sudoers configs
+  become: true
+  ansible.builtin.stat:
+    path: "{{ '/etc/sudoers.d/' + item }}"
+  loop: "{{ groups_to_purge }}"
+  register: sudoers
+
+  # The previous task may not run, so there may be nothing to kill.
+  # Setting this task to failed_when: false, since it's speculative.
+- name: Kill Persistent SSH Connection
+  local_action: >
+    ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
+    -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
+  run_once: true
+  with_items: "{{ play_hosts }}"
+  when: test_flaky_network
+  failed_when: false
+
+- name: Purge old sudoers configs
+  become: true
+  ansible.builtin.file:
+    path: "{{ item.stat.path }}"
+    state: absent
+  loop: "{{ sudoers.results }}"
+  when:
+    - item.stat.exists
+    - item.stat.isreg
+
+  # The previous task may not run, so there may be nothing to kill.
+  # Setting this task to failed_when: false, since it's speculative.
+- name: Kill Persistent SSH Connection
+  local_action: >
+    ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
+    -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
+  run_once: true
+  with_items: "{{ play_hosts }}"
+  when: test_flaky_network
+  failed_when: false
+
 - name: Ensure group management scope is configured
   become: true
   ansible.builtin.copy:

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -152,3 +152,67 @@
   with_items: "{{ play_hosts }}"
   when: test_flaky_network
   failed_when: false
+
+- name: Check group management scope
+  ansible.builtin.stat:
+    path: "{{ group_managed_scope }}"
+  register: scope
+
+- name: Kill Persistent SSH Connection
+  local_action: >
+    ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
+    -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
+  run_once: true
+  with_items: "{{ play_hosts }}"
+  when: test_flaky_network
+
+- name: Get group management scope data
+  when:
+    - scope.stat.exists
+    - scope.stat.isreg
+  block:
+    - ansible.builtin.slurp:
+        src: "{{ group_managed_scope }}"
+      register: scope_data
+    - name: Kill Persistent SSH Connection
+      local_action: >
+        ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
+        -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
+      run_once: true
+      with_items: "{{ play_hosts }}"
+      when: test_flaky_network
+    - ansible.builtin.set_fact:
+        managed_groups: "{{ (scope_data['content'] | ansible.builtin.b64decode).splitlines() }}"
+    - ansible.builtin.set_fact:
+        groups_to_purge: "{{ managed_groups | difference([group_admin, group_user]) }}"
+    - name: Purge unwanted groups
+      become: true
+      ansible.builtin.group:
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ groups_to_purge }}"
+
+  # The previous task may not run, so there may be nothing to kill.
+  # Setting this task to failed_when: false, since it's speculative.
+- name: Kill Persistent SSH Connection
+  local_action: >
+    ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
+    -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
+  run_once: true
+  with_items: "{{ play_hosts }}"
+  when: test_flaky_network
+  failed_when: false
+
+- name: Ensure group management scope is configured
+  become: true
+  ansible.builtin.copy:
+    dest: "{{ group_managed_scope }}"
+    content: "{{ [group_admin, group_user] | join('\n') + '\n' }}"
+
+- name: Kill Persistent SSH Connection
+  local_action: >
+    ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
+    -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
+  run_once: true
+  with_items: "{{ play_hosts }}"
+  when: test_flaky_network

--- a/roles/users/vars/main.yml
+++ b/roles/users/vars/main.yml
@@ -8,5 +8,6 @@ users_user:
   - monitoring
 group_admin: hamadmin
 group_user: ham
+group_managed_scope: /etc/group_managed_scope
 authorized_key_scheme: https
 authorized_key_location: monitoring.hamwan.net/keys/


### PR DESCRIPTION
Add the /etc/group_managed_scope control file, which defines the limits of the automation's scope of control over groups.  Any groups NOT listed in that file will NOT be automatically deleted.  Any groups listed in that file CAN be subject to automatic deletion when the ansible config (intent) changes to no longer require them.

This feature is analogous to users being present in managed groups, where any user that is a member of the group, but shouldn't be, falls within the scope of that group's user management, and is automatically deleted.

UNIX doesn't have the ability to put groups into other groups, or another way of grouping groups, so this /etc/group_managed_scope method needed to be invented here to express scope of management.