### PR TITLE
Private key permission management for testing

### DIFF
--- a/inventories/test/hosts.py
+++ b/inventories/test/hosts.py
@@ -3,6 +3,7 @@ import json
 import subprocess
 import locale
 import os
+import stat
 
 class VagrantIdentityFiles:
     """Caches all Vagrant SSH IdentityFile locations for fast lookup"""
@@ -35,6 +36,7 @@ class LocalIdentityFile:
     def __init__(self, relative_filename):
         self.__identityfile = os.path.join(os.path.abspath(os.path.dirname(__file__)),
                                            relative_filename)
+        os.chmod(self.__identityfile, stat.S_IRUSR | stat.S_IWUSR)
 
     def get_identityfile_or_empty(self, host):
         return self.__identityfile


### PR DESCRIPTION
ssh refuses to use inventories/test/test_ed25519 with default permissions.

There is no ssh_config override to let ssh use a private key file that's not locked down permission-wise.  Git doesn't manage permissions.  While a post-checkout hook can do the necessary "chmod 0600" operations, there is no easy way of distributing it to everyone who clones the repo.  So, here we are, putting the LocalIdentityFile class of hosts.py in charge of permissions.