### PR TITLE
Fully decouple all role variables for testing & update production users

### DIFF
--- a/roles/users/molecule/default/converge.yml
+++ b/roles/users/molecule/default/converge.yml
@@ -7,6 +7,15 @@
       ansible.builtin.include_role:
         name: "hamwan.users"
       vars:
-        authorized_key_scheme: file
+        users_admin:
+          - eo
+          - nigel
+          - tom
+        users_user:
+          - monitoring
+        group_admin: hamadmin
+        group_user: ham
+        group_managed_scope: /etc/group_managed_scope
+        authorized_key_scheme: ansible.builtin.file
         authorized_key_location: test_keys/
         test_flaky_network: true

--- a/roles/users/vars/main.yml
+++ b/roles/users/vars/main.yml
@@ -1,13 +1,22 @@
 ---
 # vars file for users
 users_admin:
+  - dylan
   - eo
+  - kc7aad
+  - KD7DK
+  - kennyr
   - nigel
+  - NQ1E
+  - nr3o
+  - osburn
   - tom
+  - ve7alb
 users_user:
   - monitoring
 group_admin: hamadmin
 group_user: ham
 group_managed_scope: /etc/group_managed_scope
-authorized_key_scheme: https
-authorized_key_location: monitoring.hamwan.net/keys/
+authorized_key_scheme: ansible.builtin.url
+authorized_key_location: https://monitoring.hamwan.net/keys/
+test_flaky_network: false


### PR DESCRIPTION
The tests relied on the role's default variables, but now the test variables are fully isolated.  This improves test stability.  For example, adding users to the role variables caused tests to break for lack of test keys for said new users.

This change also updates the live production user list with the results of a recent audit.  This is now the authoritative list of users to distribute to prod.

Lastly, some lookup() plugin names were incorrect and are now fixed.