### PR TITLE
Enable use of users role against production through new psdr.yml playbook

### DIFF
--- a/.ansible.cfg
+++ b/.ansible.cfg
@@ -1,3 +1,9 @@
 ; You can copy this file to your ~ directory to avoid specifying inventory.
 [defaults]
 inventory=~/infrastructure-configs/inventories/psdr/hosts.sh
+forks=30
+nocows=True
+gathering=explicit
+
+[ssh_connection]
+pipelining=True

--- a/README.md
+++ b/README.md
@@ -1,5 +1,20 @@
 # HamWAN Infrastructure Configs
 
+## Operator Workstation Setup (Fedora)
+
+```
+cd ~
+sudo dnf -y install ansible git
+git clone --recursive https://github.com/HamWAN/infrastructure-configs.git
+cp infrastructure-configs/.ansible.cfg ~
+```
+
+### Running the PSDR Playbook
+
+```
+ansible-playbook psdr.yml
+```
+
 ## Developer Workstation Setup (Fedora)
 ```
 sudo dnf -y install vagrant-libvirt rubygem-rexml @virtualization
@@ -7,4 +22,3 @@ sudo systemctl enable --now libvirtd
 sudo usermod --append --groups libvirt `whoami`
 vagrant up --no-parallel
 ```
-

--- a/README.md
+++ b/README.md
@@ -4,18 +4,61 @@
 
 ```
 cd ~
-sudo dnf -y install ansible git
+sudo dnf -y install ansible git jq
 git clone --recursive https://github.com/HamWAN/infrastructure-configs.git
 cp infrastructure-configs/.ansible.cfg ~
 ```
 
-### Running the PSDR Playbook
+### Listing all hosts in PSDR inventory
+
+```
+ansible --list-hosts all
+```
+
+### Listing all hosts in PSDR with OS=Linux
+
+```
+ansible --list-hosts os_linux
+```
+
+### Listing all hosts in PSDR with OS=Linux and Owner=HamWAN
+
+```
+ansible --list-hosts 'os_linux:&owner_HamWAN'
+```
+
+### Listing all hosts in PSDR with OS=Linux and Owner=HamWAN that aren't Type=Container
+
+```
+ansible --list-hosts 'os_linux:&owner_HamWAN:!type_container'
+```
+
+### General inventory exploration
+
+Now that you know the basics of group matching, you can surf the available inventory:
+
+```
+~/infrastructure-configs/inventories/psdr/hosts.sh | jq | less
+```
+
+More details about selecting inventory subsets [here](https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html#pattern-processing-order).
+
+### Running the PSDR playbook against a single server
+
+```
+ansible-playbook --limit <server> psdr.yml
+```
+
+### Running the PSDR playbook against the targets predefined inside it
 
 ```
 ansible-playbook psdr.yml
 ```
 
 ## Developer Workstation Setup (Fedora)
+
+First, run the Operator Workstation Setup, then:
+
 ```
 sudo dnf -y install vagrant-libvirt rubygem-rexml @virtualization
 sudo systemctl enable --now libvirtd

--- a/inventories/psdr/group_vars/os_linux.yml
+++ b/inventories/psdr/group_vars/os_linux.yml
@@ -1,0 +1,3 @@
+---
+ansible_ssh_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa"
+ansible_port: 222

--- a/psdr.yml
+++ b/psdr.yml
@@ -1,8 +1,7 @@
 ---
 - name: Linux User Management
   # https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html#pattern-processing-order
-  #hosts: os_linux:&owner_HamWAN:!type_container
-  hosts: name_docker0.Westin
+  hosts: os_linux:&owner_HamWAN:!type_container
   gather_facts: false
   tasks:
     - ansible.builtin.import_role:

--- a/psdr.yml
+++ b/psdr.yml
@@ -1,0 +1,9 @@
+---
+- name: Linux User Management
+  # https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html#pattern-processing-order
+  #hosts: os_linux:&owner_HamWAN:!type_container
+  hosts: name_docker0.Westin
+  gather_facts: false
+  tasks:
+    - ansible.builtin.import_role:
+        name: users


### PR DESCRIPTION
Keeping the playbook limited to 1 host for now, by default.  Making it apply network-wide is as trivial as swapping a couple comment lines though.