### PR TITLE
Update users role

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,4 +105,4 @@ deactivate
 
 ## See Also
 
-molecule/README.md
+roles/routeros_common/README.md

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ The routeros_common role tests for setting or changing settings that are both pr
 
 ## Developer Workstation Setup (Fedora)
 
+(This is likely to need updates, to match what is being installed below for Debian.
+ A Fedora user will need to do that.)
+
 First, run the Operator Workstation Setup, then:
 
 ```
@@ -87,11 +90,11 @@ cd infrastructure_configs
 virtualenv venv
 . venv/bin/activate
 pip3 install ansible-dev-tools
-pip3 install molecule ansible-core
+pip3 install molecule ansible-core ansible-pylibssh
 pip3 install --upgrade setuptools
 pip3 install "molecule-plugins[vagrant]"
 
-ansible-galaxy collection install ansible.posix
+ansible-galaxy collection install ansible.posix community.routeros
 sudo systemctl enable --now libvirtd
 sudo adduser libvirt
 
@@ -99,3 +102,7 @@ vagrant up --no-parallel
 ...
 deactivate
 ```
+
+## See Also
+
+molecule/README.md

--- a/group_vars/os_routeros.yml
+++ b/group_vars/os_routeros.yml
@@ -1,6 +1,9 @@
 ---
 # routeros_common settings for PSDR
 #
+"ansible_ssh_common_args": "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa"
+"ansible_ssh_host_key_auto_add": "true"
+
 logging_destination: 44.25.0.8
 # addresses that will be permitted to make SNMP readonly queries
 snmp_community_addresses: '44.24.240.0/20,44.25.0.0/16'

--- a/inventories/psdr/group_vars/os_routeros.yml
+++ b/inventories/psdr/group_vars/os_routeros.yml
@@ -1,0 +1,3 @@
+---
+ansible_ssh_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa"
+ansible_port: 222

--- a/inventories/test/group_vars/os_routeros.yml
+++ b/inventories/test/group_vars/os_routeros.yml
@@ -1,0 +1,3 @@
+---
+ansible_ssh_args: "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa"
+ansible_port: 22

--- a/inventories/test/routeros_hosts.py
+++ b/inventories/test/routeros_hosts.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python3
+import json
+import subprocess
+import locale
+import os
+import stat
+
+# Only usable if the identity file has the hostname in it.
+class VagrantIdentityFiles:
+    """Caches all Vagrant SSH IdentityFile locations for fast lookup"""
+
+    def __init__(self):
+        completed = subprocess.run(['/bin/sh', '-c', 'vagrant ssh-config | grep -F IdentityFile'],
+                                   capture_output=True, encoding=locale.getpreferredencoding())
+        #print(f'vagrant returned {completed}')
+        self.__identities = self.__extract_identityfiles_only(completed.stdout.splitlines())
+        #print(f'identities are {self.__identities}')
+
+    def __extract_identityfiles_only(self, identityfile_list):
+        out = []
+        for identity in identityfile_list:
+            out.append(identity.strip()[len('IdentityFile '):])
+        return out
+
+    def get_identityfile_or_empty(self, host):
+        #print(f'get_identityfile for {host}')
+        for identity in self.__identities:
+            if f'/{host}/' in identity:
+                print(f'get_identityfile found {identity}')
+                return identity
+        if len(self.__identities) == 1:
+            return self.__identities[0]
+        return ''
+
+
+# Alternative for use when using a single common identity file.
+class LocalIdentityFile:
+    """ Always returns the same local identity file """
+
+    def __init__(self, relative_filename):
+        self.__identityfile = os.path.join(os.path.abspath(os.path.dirname(__file__)),
+                                           relative_filename)
+        os.chmod(self.__identityfile, stat.S_IRUSR | stat.S_IWUSR)
+
+    def get_identityfile_or_empty(self, host):
+        return self.__identityfile
+
+
+def make_hostvars(hosts, identities, common_vars):
+    hostvars = {}
+    for host in hosts.keys():
+        identityfile = identities.get_identityfile_or_empty(host)
+        #print(f'make_hostvars - identityfile is {identityfile}')
+        if not identityfile:
+            continue
+        tmp = {}
+        tmp.update(common_vars)
+        tmp["instance"] = host
+        tmp["ansible_host"] = hosts[host]
+        tmp["ansible_ssh_private_key_file"] = identityfile
+        hostvars[host] = tmp;
+    return hostvars
+
+
+if __name__ == "__main__":
+    identities = LocalIdentityFile("/home/dpk/.vagrant.d/insecure_private_key")
+#    identities = VagrantIdentityFiles()
+    hosts = {
+        "ros6.correct": "192.168.56.20",
+        "ros6.incorrect": "192.168.56.21",
+        "ros6.missing": "192.168.56.22",
+        "ros7.correct": "192.168.56.23",
+        "ros7.incorrect": "192.168.56.24",
+        "ros7.missing": "192.168.56.25",
+    }
+    common_vars = {
+        "ansible_user": "vagrant+ct132w",
+        "ansible_port": "22",
+        "ansible_connection": "local",
+        "ansible_network_cli_ssh_type": "libssh",
+        "ansible_ssh_common_args": "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa",
+    }
+    hostvars = make_hostvars(hosts, identities, common_vars)
+    inventory = {
+        "_meta": {
+            "hostvars": hostvars,
+        },
+        "all": {
+            "hosts": list(hostvars.keys()),
+        },
+        "os_routeros": list(hostvars.keys()),
+    }
+    print(json.dumps(inventory))

--- a/inventories/test/routeros_hosts.py
+++ b/inventories/test/routeros_hosts.py
@@ -71,6 +71,7 @@ def make_hostvars(hosts, identities, common_vars):
 if __name__ == "__main__":
     identities = LocalIdentityFile(f"{os.environ['HOME']}/.vagrant.d/insecure_private_key")
 #    identities = VagrantIdentityFiles()
+    # These need to match the Vagrant configuration in roles/routeros_common/molecule/default
     hosts = {
         "ros6.correct": "192.168.56.20",
         "ros6.incorrect": "192.168.56.21",

--- a/inventories/test/routeros_hosts.py
+++ b/inventories/test/routeros_hosts.py
@@ -1,4 +1,10 @@
 #!/usr/bin/python3
+'''Produces a json formated invemntory of Vagrant hosts that will be used
+   for testing routeros_common role.  The inventory contains information that
+   will be needed for connecting to the test instances.
+
+   See roles/routeros_common/README.md for some more description of testing strategy.
+'''
 import json
 import subprocess
 import locale
@@ -63,7 +69,7 @@ def make_hostvars(hosts, identities, common_vars):
 
 
 if __name__ == "__main__":
-    identities = LocalIdentityFile("/home/dpk/.vagrant.d/insecure_private_key")
+    identities = LocalIdentityFile(f"{os.environ['HOME']}/.vagrant.d/insecure_private_key")
 #    identities = VagrantIdentityFiles()
     hosts = {
         "ros6.correct": "192.168.56.20",

--- a/psdr.yml
+++ b/psdr.yml
@@ -11,7 +11,7 @@
 
 - name: Linux User Management
   # https://docs.ansible.com/ansible/latest/inventory_guide/intro_patterns.html#pattern-processing-order
-  hosts: os_linux:&owner_HamWAN:!type_container
+  hosts: os_linux:&owner_HamWAN:!type_container:!type_anycast
   gather_facts: false
   roles:
     - users

--- a/roles/requirements.yml
+++ b/roles/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
   - ansible.posix
+  - community.routeros

--- a/roles/routeros_common/README.md
+++ b/roles/routeros_common/README.md
@@ -9,3 +9,24 @@ By putting the values in group_vars, the can be overriden where needed by entrie
 It is currently tested against routeros versions up to 6.1-6.49.x and 7.1-7.16.
 
 The user is expected to have SSH access to the devices.
+
+## Testing
+
+We use molecule to drive automated testing using Vagrant and VirtualBox based routeros images.
+Vagrant is going to build 6 RouterOS images.  Three each for RouterOS 6 and RouterOS 7.
+Each is in a specific initial state for each of the settings we are going to test:
+
+ - correct - the setting are already as we would expect.  No change should be applied.
+ - incorrect - all the settings are present but wrong.  They should all be corrected.
+ - missing - where possible, the setting are unset or missing.  They should be set or ignored (situationly dependent).
+
+### References
+
+The source for our routeros images:
+https://github.com/cheretbe/packer-routeros/tree/master
+
+Some useful description of using molecule and Vagrant for testing:
+https://floatingpoint.sorint.it/blog/post/setting-up-molecule-for-testing-ansible-roles-with-vagrant-and-testinfra
+
+Vagrant docs:
+https://developer.hashicorp.com/vagrant/docs/providers/basic_usage

--- a/roles/routeros_common/molecule/default/Vagrantfile
+++ b/roles/routeros_common/molecule/default/Vagrantfile
@@ -12,31 +12,37 @@ Vagrant.configure("2") do |config|
       "name" => 'ros6.correct',
       "ip" => '192.168.56.20',
       "box" => 'cheretbe/routeros',
+      "host_config" => 'correct.rsc',
     },
     {
       "name" => 'ros6.incorrect',
       "ip" => '192.168.56.21',
       "box" => 'cheretbe/routeros',
+      "host_config" => 'incorrect.rsc',
     },
     {
       "name" => 'ros6.missing',
       "ip" => '192.168.56.22',
       "box" => 'cheretbe/routeros',
+      "host_config" => 'missing.rsc',
     },
     {
       "name" => 'ros7.correct',
       "ip" => '192.168.56.23',
       "box" => 'cheretbe/routeros7',
+      "host_config" => 'correct.rsc',
     },
     {
       "name" => 'ros7.incorrect',
       "ip" => '192.168.56.24',
       "box" => 'cheretbe/routeros7',
+      "host_config" => 'incorrect.rsc',
     },
     {
       "name" => 'ros7.missing',
       "ip" => '192.168.56.25',
       "box" => 'cheretbe/routeros7',
+      "host_config" => 'missing.rsc',
     },
   ]
  
@@ -66,7 +72,7 @@ Vagrant.configure("2") do |config|
       node.vm.provision "routeros_file", name: "Upload initial common configuration", source: "provision/common.rsc", destination: "common.rsc"
       node.vm.provision "routeros_command", name: "Exec custom script", command: "/import common.rsc", check_script_error: true
       # Upload and execute a test specific script file
-      node.vm.provision "routeros_file", name: "Upload initial host configuration", source: "provision/#{vm["name"].sub(/ros.\./, '')}.rsc", destination: "host.rsc"
+      node.vm.provision "routeros_file", name: "Upload initial host configuration", source: "provision/#{vm["host_config"]}", destination: "host.rsc"
       node.vm.provision "routeros_command", name: "Exec test configuration", command: "/import host.rsc", check_script_error: true
     end
   end

--- a/roles/routeros_common/molecule/default/Vagrantfile
+++ b/roles/routeros_common/molecule/default/Vagrantfile
@@ -9,14 +9,34 @@ Vagrant.configure("2") do |config|
 
   VMs = [
     {
-      "name" => 'ROS7.test',
+      "name" => 'ros6.correct',
       "ip" => '192.168.56.20',
+      "box" => 'cheretbe/routeros',
+    },
+    {
+      "name" => 'ros6.incorrect',
+      "ip" => '192.168.56.21',
+      "box" => 'cheretbe/routeros',
+    },
+    {
+      "name" => 'ros6.missing',
+      "ip" => '192.168.56.22',
+      "box" => 'cheretbe/routeros',
+    },
+    {
+      "name" => 'ros7.correct',
+      "ip" => '192.168.56.23',
       "box" => 'cheretbe/routeros7',
     },
     {
-      "name" => 'ROS6.test',
-      "ip" => '192.168.56.21',
-      "box" => 'cheretbe/routeros',
+      "name" => 'ros7.incorrect',
+      "ip" => '192.168.56.24',
+      "box" => 'cheretbe/routeros7',
+    },
+    {
+      "name" => 'ros7.missing',
+      "ip" => '192.168.56.25',
+      "box" => 'cheretbe/routeros7',
     },
   ]
  
@@ -26,6 +46,7 @@ Vagrant.configure("2") do |config|
       node.vm.hostname = vm["name"]
       node.vm.box = vm["box"]
       node.vm.network "private_network", virtualbox__intnet: "vagrant-intnet-1", auto_config: false
+
       # Disable automatic box update checking. If you disable this, then
       # boxes will only be checked for updates when the user runs
       # `vagrant box outdated`. This is not recommended.
@@ -40,11 +61,13 @@ Vagrant.configure("2") do |config|
       # Disable DHCP client and force address to known address (inventories/test/routeros_common.py)
       node.vm.provision "routeros_command", name: "Disable DHCP client on host_only", command: "/ip dhcp-client disable [find interface=host_only]"
       node.vm.provision "routeros_command", name: "Add IP address", command: "/ip address add interface=host_only address=#{vm['ip']}/24"
-      # Upload and execute a setup script file
-      node.vm.provision "routeros_file", name: "Upload initial common configuration", source: "provision/common_setup.rsc", destination: "common_setup.rsc"
-      node.vm.provision "routeros_command", name: "Exec custom script", command: "/import common_setup.rsc", check_script_error: true
-      node.vm.provision "routeros_file", name: "Upload initial host configuration", source: "provision/#{vm['name']}.rsc", destination: "host_setup.rsc"
-      node.vm.provision "routeros_command", name: "Set host IP", command: "/import host_setup.rsc", check_script_error: true
+
+      # Upload and execute a common script file
+      node.vm.provision "routeros_file", name: "Upload initial common configuration", source: "provision/common.rsc", destination: "common.rsc"
+      node.vm.provision "routeros_command", name: "Exec custom script", command: "/import common.rsc", check_script_error: true
+      # Upload and execute a test specific script file
+      node.vm.provision "routeros_file", name: "Upload initial host configuration", source: "provision/#{vm["name"].sub(/ros.\./, '')}.rsc", destination: "host.rsc"
+      node.vm.provision "routeros_command", name: "Exec test configuration", command: "/import host.rsc", check_script_error: true
     end
   end
 end

--- a/roles/routeros_common/molecule/default/check_value.yml
+++ b/roles/routeros_common/molecule/default/check_value.yml
@@ -1,0 +1,19 @@
+---
+# Check RouterOS setting
+# Derived from ../../tasks/check_and_set_value.yml, omitting unneeded tasks
+
+- name: get_facts
+  # sets current_value
+  ansible.builtin.include_tasks:
+    file: ../../tasks/get_facts.yml
+
+- name: "Show filtered variable {{ item.name }}"
+  ansible.builtin.debug:
+    msg: "query_result.stdout[0] filtered: {{ query_result.stdout[0] | regex_replace('=.\n +', '=') }}"
+    verbosity: 1
+
+- name: "Check correctness of {{ item.name }}"
+  ansible.builtin.set_fact:
+    # The regex here is just joining the split lines back together
+    is_correct: "{{ item.desired_value in (query_result.stdout[0] | regex_replace('=.\n +', '=')) or (item.missing_ok and current_value == '') or item.prefix|default('') not in current_value }}"
+  failed_when: not is_correct

--- a/roles/routeros_common/molecule/default/converge.yml
+++ b/roles/routeros_common/molecule/default/converge.yml
@@ -3,6 +3,15 @@
   hosts: all
   gather_facts: false
   tasks:
-    - name: Replace this task with one that validates your content
-      ansible.builtin.debug:
-        msg: "This is the effective test"
+    - name: "Include group vars for os_routeros"
+      ansible.builtin.include_vars: ../../../../group_vars/os_routeros.yml
+
+    - name: "Include hamwan.routeros_common"
+      ansible.builtin.include_role:
+        name: routeros_common
+      vars:
+        test_flaky_network: true
+        # TODO(dpk) - The following should be coming from the inventory, but aren't. Why?
+        ansible_port: 22
+        ansible_user: vagrant+ct132w
+        ansible_ssh_private_key_file: "/home/dpk/.vagrant.d/insecure_private_key"

--- a/roles/routeros_common/molecule/default/create.yml
+++ b/roles/routeros_common/molecule/default/create.yml
@@ -3,21 +3,40 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  # no_log: "{{ molecule_no_log }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     # TODO: Developer must implement and populate 'server' variable
+
+    - name: Ensure Vagrant instances are up
+      ansible.builtin.command:
+        cmd: "vagrant up {{ item.name }}"
+      throttle: 1
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Get Ansible test inventory
+      ansible.builtin.command:
+        cmd: "../../../../inventories/test/routeros_hosts.py"
+      register: inventory
+      changed_when: false
+
+    - name: Transform inventory into Molecule compatible format
+      ansible.builtin.set_fact:
+        server: {
+          'changed': true,
+          'results': "{{ (inventory.stdout | from_json)._meta.hostvars }}",
+        }
 
     - name: Create instance config
       when: server.changed | default(false) | bool  # noqa no-handler
       block:
         - name: Populate instance config dict  # noqa jinja
           ansible.builtin.set_fact:
-            instance_conf_dict: {}
-            # instance': "{{ }}",
-            # address': "{{ }}",
-            # user': "{{ }}",
-            # port': "{{ }}",
-            # 'identity_file': "{{ }}", }
+            instance_conf_dict: {
+              'instance': "{{ server.results[item].instance }}",
+              'address': "{{ server.results[item].ansible_host }}",
+              'user': "{{ server.results[item].ansible_user }}",
+              'port': "{{ server.results[item].ansible_port  }}",
+              'identity_file': "{{ server.results[item].ansible_ssh_private_key_file }}", }
           with_items: "{{ server.results }}"
           register: instance_config_dict
 

--- a/roles/routeros_common/molecule/default/destroy.yml
+++ b/roles/routeros_common/molecule/default/destroy.yml
@@ -3,11 +3,17 @@
   hosts: localhost
   connection: local
   gather_facts: false
-  # no_log: "{{ molecule_no_log }}"
+  no_log: "{{ molecule_no_log }}"
   tasks:
     # Developer must implement.
 
     # Mandatory configuration for Molecule to function.
+
+    - name: Destroy Vagrant instances
+      ansible.builtin.command:
+        cmd: "vagrant destroy -f {{ item.name }}"
+      throttle: 1
+      loop: "{{ molecule_yml.platforms }}"
 
     - name: Populate instance config
       ansible.builtin.set_fact:

--- a/roles/routeros_common/molecule/default/molecule.yml
+++ b/roles/routeros_common/molecule/default/molecule.yml
@@ -1,15 +1,15 @@
 ---
 dependency:
   name: galaxy
-#driver:
-#  name: vagrant
+driver:
+  name: default
 platforms:
-  - name: test.ros6.missing
-  - name: test.ros6.incorrect
-  - name: test.ros6.updated
-  - name: test.ros7.missing
-  - name: test.ros7.incorrect
-  - name: test.ros7.updated
+  - name: ros6.correct
+  - name: ros6.incorrect
+  - name: ros6.missing
+  - name: ros7.correct
+  - name: ros7.incorrect
+  - name: ros7.missing
 provisioner:
   name: ansible
   log: True

--- a/roles/routeros_common/molecule/default/provision/common.rsc
+++ b/roles/routeros_common/molecule/default/provision/common.rsc
@@ -48,11 +48,6 @@ if ([:len [/interface list member find list="ALLOW_DISCOVERY" and interface="hos
   /interface list member add list=ALLOW_DISCOVERY interface=host_only comment="defconf"
 }
 
-if (![/ip dns get allow-remote-requests]) do={
-  :put "Enabling DNS server"
-  /ip dns set allow-remote-requests=yes
-}
-
 if ([:len [/ip firewall filter find]] = 0) do={
   :put "Adding firewall rules"
   /ip firewall {

--- a/roles/routeros_common/molecule/default/provision/correct.rsc
+++ b/roles/routeros_common/molecule/default/provision/correct.rsc
@@ -1,0 +1,38 @@
+:put "Correct settings for HamWAN RouterOS devices"
+
+:put "Set remote logging destination"
+/system logging action set [find name=remote] bsd-syslog=no name=remote remote=44.25.0.8 remote-port=514 src-address=0.0.0.0 syslog-facility=daemon syslog-severity=auto target=remote
+
+:put "Setting SNMP address range"
+/snmp community set name=hamwan addresses=44.24.240.0/20,44.25.0.0/16 read-access=yes write-access=no numbers=0
+
+:put "Setting HamWAN DNS servers"
+/ip dns set servers=44.25.0.1,44.25.1.1
+
+:put "Disabling remote DNS requests (DNS proxy)"
+/ip dns set allow-remote-requests=no
+
+:put "Create dummy interface with DHCP on subnet 44.25.123.0/24"
+/ip pool add name=pool1 ranges=44.25.123.2-44.25.123.254
+/in bridge add name=dummy1
+/ip address add interface=dummy1 address=44.25.123.1/24
+/ip dhcp-server add address-pool=pool1 authoritative=after-2sec-delay interface=dummy1 lease-time=1h name=dhcp99
+/ip dhcp-server network add address=44.25.123.0/24 dns-server=44.25.0.1,44.25.1.1 domain=HamWAN.net gateway=44.25.123.1 ntp-server=44.25.0.4,44.25.1.4
+
+:put "Setting client NTP servers"
+:local rosver [/system resource get version]
+:if ($rosver~"^7.*") do={
+    ;put "RouterOS 7.x settings";
+    :global command [:parse "/system ntp client set enabled=yes servers=44.25.0.4,44.25.1.4"]
+} else={
+    ;put "RouterOS 6.x settings";
+    :global command [:parse "/system ntp client set enabled=yes primary-ntp=44.25.0.4 secondary-ntp=44.25.1.4"]
+}
+:put "Using command $command"
+$command
+
+# Not part of the core yet
+:put "Setting time zone to America/Los_Angeles"
+/system clock set time-zone-name=America/Los_Angeles
+:put "Setting up SNMP"
+/snmp set enabled=yes contact="#hamwan-support on libera.chat"

--- a/roles/routeros_common/molecule/default/provision/incorrect.rsc
+++ b/roles/routeros_common/molecule/default/provision/incorrect.rsc
@@ -1,0 +1,39 @@
+:put "Incorrect settings for HamWAN RouterOS devices"
+
+:put "Set remote logging destination"
+/system logging action set [find name=remote] bsd-syslog=no name=remote remote=1.2.3.4 remote-port=514 src-address=0.0.0.0 syslog-facility=daemon syslog-severity=auto target=remote
+
+:put "Setting SNMP address range"
+/snmp community set name=hamwan addresses=44.24.240.0/20 read-access=yes write-access=no numbers=0
+
+:put "Setting HamWAN DNS servers"
+/ip dns set servers=44.24.245.1,44.24.244.1
+
+:put "Disabling remote DNS requests (DNS proxy)"
+/ip dns set allow-remote-requests=yes
+
+:put "Create dummy interface with DHCP on subnet 44.24.243.0/28"
+/ip pool add name=pool1 ranges=44.24.243.2-44.24.243.14
+/in bridge add name=dummy1
+/ip address add interface=dummy1 address=44.24.243.1/28
+/ip dhcp-server add address-pool=pool1 authoritative=after-2sec-delay interface=dummy1 lease-time=1h name=dhcp99
+/ip dhcp-server network add address=44.24.243.0/28 dns-server=44.24.244.1,44.24.245.1 domain=HamWAN.net gateway=44.25.243.1 ntp-server=44.24.244.4,44.24.245.4
+
+# Setup NTP client settings
+:put "Setting client NTP servers"
+:local rosver [/system resource get version]
+:if ($rosver~"^7.*") do={
+    ;put "RouterOS 7.x settings";
+    :global command [:parse "/system ntp client set enabled=yes servers=44.24.244.4,44.24.245.4"]
+} else={
+    ;put "RouterOS 6.x settings";
+    :global command [:parse "/system ntp client set enabled=yes primary-ntp=44.24.244.4 secondary-ntp=44.24.245.4"]
+}
+:put "Using command $command"
+$command
+
+# Not part of the core yet
+:put "Setting time zone to America/Los_Angeles"
+/system clock set time-zone-name=America/Chicago
+:put "Setting up SNMP"
+/snmp set enabled=yes contact="#hamwan-support on some other irc.chat.com"

--- a/roles/routeros_common/molecule/default/provision/missing.rsc
+++ b/roles/routeros_common/molecule/default/provision/missing.rsc
@@ -1,0 +1,29 @@
+:put "Missing setting for HamWAN RouterOS devices"
+
+:put "Setting Empty HamWAN DNS servers"
+/ip dns set servers=""
+
+:put "Create dummy interface with DHCP on non-HamWAN subnet 44.12.1.0/28"
+/ip pool add name=pool1 ranges=44.12.1.2-44.12.1.14
+/in bridge add name=dummy1
+/ip address add interface=dummy1 address=44.12.1.1/28
+/ip dhcp-server add address-pool=pool1 authoritative=after-2sec-delay interface=dummy1 lease-time=1h name=dhcp99
+/ip dhcp-server network add address=44.12.1.0/28 dns-server=1.1.1.1,2.2.2.2 domain=HamWAN.net gateway=44.12.1.1 ntp-server=3.3.3.3,4.4.4.4
+
+:put "Setup NTP client settings"
+:local rosver [/system resource get version];
+:if ($rosver~"^7.*") do={
+    ;put "RouterOS 7.x settings";
+    :global command [:parse "/system ntp client set enabled=no servers=\"\""]
+} else={
+    ;put "RouterOS 6.x settings";
+    :global command [:parse "/system ntp client set enabled=no primary-ntp=0.0.0.0 secondary-ntp=0.0.0.0"]
+}
+:put "Using command $command"
+$command
+
+# Not part of the core yet
+:put "Setting time zone to America/Los_Angeles"
+/system clock set time-zone-name=America/Los_Angeles
+:put "Setting up SNMP"
+/snmp set enabled=yes contact="#hamwan-support on libera.chat"

--- a/roles/routeros_common/molecule/default/verify.yml
+++ b/roles/routeros_common/molecule/default/verify.yml
@@ -1,0 +1,33 @@
+---
+- name: Verify installation or correction of settings
+  hosts: all
+  gather_facts: false
+
+  tasks:
+    - name: "Include group vars for os_routeros"
+      ansible.builtin.include_vars: ../../../../group_vars/os_routeros.yml
+
+    - name: "Include default settings"
+      ansible.builtin.include_vars: ../../vars/main.yml
+
+    - name: collect facts
+      ansible.builtin.include_tasks:
+        file: ../../tasks/get_facts.yml
+      loop: "{{ routeros_facts }}"
+
+    - name: common settings
+      ansible.builtin.include_tasks:
+        file: check_value.yml
+      loop: "{{ settings.simple_settings }}"
+
+    - name: v6 common settings
+      ansible.builtin.include_tasks:
+        file: check_value.yml
+      loop: "{{ settings.v6_simple_settings }}"
+      when: routeros_version is match("^6.")
+
+    - name: v7 common settings
+      ansible.builtin.include_tasks:
+        file: check_value.yml
+      loop: "{{ settings.v7_simple_settings }}"
+      when: routeros_version is match("^7.")

--- a/roles/routeros_common/provision
+++ b/roles/routeros_common/provision
@@ -1,0 +1,1 @@
+molecule/default/provision

--- a/roles/routeros_common/provision/ROS6.test.rsc
+++ b/roles/routeros_common/provision/ROS6.test.rsc
@@ -1,1 +1,0 @@
-/user add name=ROS6-user group=full password=vagrant

--- a/roles/routeros_common/provision/ROS7.test.rsc
+++ b/roles/routeros_common/provision/ROS7.test.rsc
@@ -1,5 +1,0 @@
-if ([:len [/user find name="ROS7-user"]] = 0) do={
-  :put "Adding user ROS7-user"
-  /user add name=ROS7-user group=full password=vagrant
-}
-

--- a/roles/routeros_common/tasks/check_and_set_value.yml
+++ b/roles/routeros_common/tasks/check_and_set_value.yml
@@ -1,14 +1,57 @@
 ---
 # Check and correct RouterOS setting
 
+  # There may be an existing Persistent SSH from other commands.
+  # Setting this task to failed_when: false, since it's speculative.
+  # ... and this is broken for Vagrant (ControlPath naming is wrong)
+  # TODO(dpk): investigate and fix this if possible (vagrant, molecule, ansible.community.routeros issue I believe)
+  #            should also move to a task file that is included rather than repeating the code over and over.
+- name: Kill Persistent SSH Connection
+  local_action: >
+    ansible.builtin.shell ssh -O exit {{ hostvars[host].ansible_host }}
+    -o ControlPath=~/.ansible/cp/{{ hostvars[host].ansible_host }}-{{ hostvars[host].ansible_port }}-{{ hostvars[host].ansible_user }}
+  run_once: true
+  loop: "{{ play_hosts }}"
+  loop_control:
+    loop_var: host
+  when: test_flaky_network
+  changed_when: false
+  failed_when: false
+
 - name: get_facts
   # sets current_value
   ansible.builtin.include_tasks:
     file: get_facts.yml
 
+  # Setting this task to failed_when: false, since it's speculative.
+- name: Kill Persistent SSH Connection
+  local_action: >
+    ansible.builtin.shell ssh -O exit {{ hostvars[host].ansible_host }}
+    -o ControlPath=~/.ansible/cp/{{ hostvars[host].ansible_host }}-{{ hostvars[host].ansible_port }}-{{ hostvars[host].ansible_user }}
+  run_once: true
+  loop: "{{ play_hosts }}"
+  loop_control:
+    loop_var: host
+  when: test_flaky_network
+  changed_when: false
+  failed_when: false
+
 - name: "Check correctness of {{ item.name }}"
   ansible.builtin.set_fact:
-    is_correct: "{{ item.desired_value in query_result.stdout[0] or (item.missing_ok and current_value == '') }}"
+    is_correct: "{{ item.desired_value in query_result.stdout[0] or (item.missing_ok and current_value == '') or item.prefix|default('') not in current_value }}"
+
+  # Setting this task to failed_when: false, since it's speculative.
+- name: Kill Persistent SSH Connection
+  local_action: >
+    ansible.builtin.shell ssh -O exit {{ hostvars[host].ansible_host }}
+    -o ControlPath=~/.ansible/cp/{{ hostvars[host].ansible_host }}-{{ hostvars[host].ansible_port }}-{{ hostvars[host].ansible_user }}
+  run_once: true
+  loop: "{{ play_hosts }}"
+  loop_control:
+    loop_var: host
+  when: test_flaky_network and not is_correct
+  changed_when: false
+  failed_when: false
 
 - name: "Show diff and corrective action for {{ item.name }}"
   ansible.builtin.debug:

--- a/roles/routeros_common/vars/main.yml
+++ b/roles/routeros_common/vars/main.yml
@@ -15,9 +15,7 @@
 "ansible_connection": "ansible.netcommon.network_cli"
 "ansible_network_cli_ssh_type": "libssh"
 "ansible_network_os": "routeros"
-"ansible_port": "222"
 "ansible_ssh_host_key_auto_add": "true"
-"ansible_ssh_common_args": "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa"
 
 routeros_facts:
   - name: routeros_version
@@ -38,7 +36,7 @@ default_simple_settings:
     query_command: '/snmp community print detail where name=hamwan'
     desired_value: 'addresses={{ snmp_community_addresses }}'
     pattern: '.*addresses=(\S*).*'
-    set_command: '/snmp community set [ find name=hamwan ] name=hamwan addresses={{ snmp_community_addresses }}'
+    set_command: '/snmp community set [ find name~"hamwan|public" ] name=hamwan addresses={{ snmp_community_addresses }}'
     missing_ok: false
 
   - name: dns_servers
@@ -63,6 +61,7 @@ default_simple_settings:
     pattern: '.*dns-server=(\S*).*'
     # Using find here in so we deal gracefully with multiple or no DHCP servers
     set_command: '/ip dhcp-server network set [ find dns-server~"{{dhcp_dns_server_target_prefix}}" ] dns-server={{ dhcp_dns_server }}'
+    prefix: '{{dhcp_dns_server_target_prefix}}'
     missing_ok: true
 
   - name: dhcp_ntp_server
@@ -71,6 +70,7 @@ default_simple_settings:
     pattern: '.*ntp-server=(\S*).*'
     # Using find here in so we deal gracefully with multiple or no DHCP servers
     set_command: '/ip dhcp-server network set [ find ntp-server~"{{dhcp_ntp_server_target_prefix}}" ] ntp-server={{ dhcp_ntp_server }}'
+    prefix: '{{dhcp_ntp_server_target_prefix}}'
     missing_ok: true
 
   - name: time_zone_name


### PR DESCRIPTION
Unfortunately there are two unrelated changes in this pull request.
9556c99 - this is a trivial change to make the Unix user management not try to install users on anycast instances.
The other two (c9f2057 and 79ac820) should have been in a separate branch and represent the initial support for testing of the routeros_common role.  This is a BIG addition to the code.  It has been tested and is in a working state, but can be optimized and refactored a bit to eliminate some code duplications (notes in the code).  That will com in subsequent CLs.