### PR TITLE
Ansible updates (remove 44.24.240.0/20 SNMP access, deprecation changes, SSH changes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,20 @@ host_key_checking = False
 or set the environment variable ```ANSIBLE_HOST_KEY_CHECKING=False```
 on the ansible command line or for your shell session.
 
+In addtion, recent changes to libssh restrict the default available algorithm choices
+to more secure options. This will prevent connections to older RouterOS versions.
+You will probably want to update your ```~/.ssh/config``` file with a stanza similar to this:
+
+```
+Host *.hamwan.net
+    MACs +hmac-sha1
+    KexAlgorithms +diffie-hellman-group14-sha1
+    HostKeyAlgorithms +ssh-rsa
+    PubkeyAcceptedAlgorithms +ssh-rsa
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+```
+
 # HamWAN Infrastructure Configs
 
 ## Organization (Site) Specific Information

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# General Comments
+
+## SSH configuration issue
+
+SSH is used heavily by ansible to access Linux and RouterOS. Recent librar changes make it more
+paranoid about accessing hosts that are not in your known hosts file. You will need to either
+update your ansible.cfg file:
+
+```
+[defaults]
+host_key_checking = False
+```
+
+or set the environment variable ```ANSIBLE_HOST_KEY_CHECKING=False```
+on the ansible command line or for your shell session.
+
 # HamWAN Infrastructure Configs
 
 ## Organization (Site) Specific Information
@@ -5,6 +21,8 @@
 Information on accessing organization hosts is stored in inventories/_site_/group_vars/_group_.yml.
 In the HamWAN case, all the hosts we manage are in the group owner_HamWAN, so we have a group_vars file
 owner_HamWAN.yml.
+
+RouterOS specific configuration information is in group_vars/os_routeros.yml.
 
 ```
 ---

--- a/group_vars/os_routeros.yml
+++ b/group_vars/os_routeros.yml
@@ -1,8 +1,7 @@
 ---
 # routeros_common settings for PSDR
 #
-"ansible_ssh_common_args": "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa -o MACS=hmac-sha1,hmac-md5 -o HostKeyAlgorithms=+ssh-rsa -o KexAlgorithms=+diffie-hellman-group14-sha1"
-"ansible_ssh_host_key_auto_add": "true"
+ansible_ssh_host_key_auto_add: "true"
 
 logging_destination: 44.25.0.8
 # addresses that will be permitted to make SNMP readonly queries

--- a/group_vars/os_routeros.yml
+++ b/group_vars/os_routeros.yml
@@ -6,7 +6,7 @@
 
 logging_destination: 44.25.0.8
 # addresses that will be permitted to make SNMP readonly queries
-snmp_community_addresses: '44.24.240.0/20,44.25.0.0/16'
+snmp_community_addresses: '44.25.0.0/16'
 # what DNS servers should the routeros device use
 dns_servers: '44.25.0.1,44.25.1.1'
 # dns_allow_remote_requests should almost always be 'no' to prevent being used for DDOS

--- a/group_vars/os_routeros.yml
+++ b/group_vars/os_routeros.yml
@@ -1,7 +1,7 @@
 ---
 # routeros_common settings for PSDR
 #
-"ansible_ssh_common_args": "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa"
+"ansible_ssh_common_args": "-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o PubkeyAcceptedKeyTypes=+ssh-rsa -o MACS=hmac-sha1,hmac-md5 -o HostKeyAlgorithms=+ssh-rsa -o KexAlgorithms=+diffie-hellman-group14-sha1"
 "ansible_ssh_host_key_auto_add": "true"
 
 logging_destination: 44.25.0.8

--- a/host_vars/S1.Triangle.hamwan.net
+++ b/host_vars/S1.Triangle.hamwan.net
@@ -3,7 +3,7 @@
 # Set alternate snmp addresses and dns servers, and remove tasks to manage dhcp servers.
 #
 # addresses that will be permitted to make SNMP readonly queries
-snmp_community_addresses: '44.24.240.0/20,44.25.0.0/16,44.135.193.0/24,44.135.219.0/24'
+snmp_community_addresses: '44.25.0.0/16,44.135.193.0/24,44.135.219.0/24'
 # what DNS servers should the routeros device use
 dns_servers: '44.31.125.225,44.31.125.226'
 

--- a/host_vars/S2.Triangle.hamwan.net
+++ b/host_vars/S2.Triangle.hamwan.net
@@ -3,7 +3,7 @@
 # Set alternate snmp addresses and dns servers, and remove tasks to manage dhcp servers.
 #
 # addresses that will be permitted to make SNMP readonly queries
-snmp_community_addresses: '44.24.240.0/20,44.25.0.0/16,44.135.193.0/24,44.135.219.0/24'
+snmp_community_addresses: '44.25.0.0/16,44.135.193.0/24,44.135.219.0/24'
 # what DNS servers should the routeros device use
 dns_servers: '44.31.125.225,44.31.125.226'
 

--- a/roles/routeros_common/README.md
+++ b/roles/routeros_common/README.md
@@ -10,6 +10,13 @@ It is currently tested against routeros versions up to 6.1-6.49.x and 7.1-7.16.
 
 The user is expected to have SSH access to the devices.
 
+NOTE: Due to the way RouterOS echos characters back on the SSH session, you will need to change
+the ansible remote username when using this role against RouterOS devices. If your username is
+"myname", then you will need to set the ansible remote user to "myname+cet512w". The "+cet512w"
+sets some terminal options for the ssh session to ensure anssible can parse the output successfully.
+
+   [https://docs.ansible.com/projects/ansible/latest/network/user_guide/platform_routeros.html]
+
 ## Testing
 
 We use molecule to drive automated testing using Vagrant and VirtualBox based routeros images.

--- a/roles/routeros_common/README.md
+++ b/roles/routeros_common/README.md
@@ -14,8 +14,9 @@ NOTE: Due to the way RouterOS echos characters back on the SSH session, you will
 the ansible remote username when using this role against RouterOS devices. If your username is
 "myname", then you will need to set the ansible remote user to "myname+cet512w". The "+cet512w"
 sets some terminal options for the ssh session to ensure anssible can parse the output successfully.
-
-   [https://docs.ansible.com/projects/ansible/latest/network/user_guide/platform_routeros.html]
+This is explained in some more detail here:
+https://docs.ansible.com/projects/ansible/latest/network/user_guide/platform_routeros.html
+and here: https://help.mikrotik.com/docs/spaces/ROS/pages/328134/Command+Line+Interface
 
 ## Testing
 

--- a/roles/routeros_common/molecule/default/provision/correct.rsc
+++ b/roles/routeros_common/molecule/default/provision/correct.rsc
@@ -4,7 +4,7 @@
 /system logging action set [find name=remote] bsd-syslog=no name=remote remote=44.25.0.8 remote-port=514 src-address=0.0.0.0 syslog-facility=daemon syslog-severity=auto target=remote
 
 :put "Setting SNMP address range"
-/snmp community set name=hamwan addresses=44.24.240.0/20,44.25.0.0/16 read-access=yes write-access=no numbers=0
+/snmp community set name=hamwan addresses=44.25.0.0/16 read-access=yes write-access=no numbers=0
 
 :put "Setting HamWAN DNS servers"
 /ip dns set servers=44.25.0.1,44.25.1.1

--- a/roles/routeros_common/molecule/default/provision/incorrect.rsc
+++ b/roles/routeros_common/molecule/default/provision/incorrect.rsc
@@ -4,7 +4,7 @@
 /system logging action set [find name=remote] bsd-syslog=no name=remote remote=1.2.3.4 remote-port=514 src-address=0.0.0.0 syslog-facility=daemon syslog-severity=auto target=remote
 
 :put "Setting SNMP address range"
-/snmp community set name=hamwan addresses=44.24.240.0/20 read-access=yes write-access=no numbers=0
+/snmp community set name=hamwan addresses=44.24.240.0/20,44.25.0.0/16 read-access=yes write-access=no numbers=0
 
 :put "Setting HamWAN DNS servers"
 /ip dns set servers=44.24.245.1,44.24.244.1

--- a/roles/routeros_common/tasks/check_and_set_value.yml
+++ b/roles/routeros_common/tasks/check_and_set_value.yml
@@ -11,7 +11,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[host].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[host].ansible_host }}-{{ hostvars[host].ansible_port }}-{{ hostvars[host].ansible_user }}
   run_once: true
-  loop: "{{ play_hosts }}"
+  loop: "{{ ansible_play_batch }}"
   loop_control:
     loop_var: host
   when: test_flaky_network
@@ -29,7 +29,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[host].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[host].ansible_host }}-{{ hostvars[host].ansible_port }}-{{ hostvars[host].ansible_user }}
   run_once: true
-  loop: "{{ play_hosts }}"
+  loop: "{{ ansible_play_batch }}"
   loop_control:
     loop_var: host
   when: test_flaky_network
@@ -46,7 +46,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[host].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[host].ansible_host }}-{{ hostvars[host].ansible_port }}-{{ hostvars[host].ansible_user }}
   run_once: true
-  loop: "{{ play_hosts }}"
+  loop: "{{ ansible_play_batch }}"
   loop_control:
     loop_var: host
   when: test_flaky_network and not is_correct

--- a/roles/users/tasks/main.yml
+++ b/roles/users/tasks/main.yml
@@ -18,7 +18,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
   failed_when: false
@@ -36,7 +36,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
 
@@ -55,7 +55,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
 
@@ -72,7 +72,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
 
@@ -89,7 +89,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
 
@@ -106,7 +106,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
 
@@ -115,14 +115,14 @@
     database: group
     key: "{{ group_admin }}"
 - ansible.builtin.set_fact:
-    users_to_purge: "{{ getent_group[group_admin][2].split(',') | difference(users_admin) }}"
+    users_to_purge: "{{ ansible_facts['getent_group'][group_admin][2].split(',') | difference(users_admin) }}"
 
 - name: Kill Persistent SSH Connection
   local_action: >
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
 
@@ -131,14 +131,14 @@
     database: group
     key: "{{ group_user }}"
 - ansible.builtin.set_fact:
-    users_to_purge: "{{ getent_group[group_user][2].split(',') | difference(users_user) + users_to_purge }}"
+    users_to_purge: "{{ ansible_facts['getent_group'][group_user][2].split(',') | difference(users_user) + users_to_purge }}"
 
 - name: Kill Persistent SSH Connection
   local_action: >
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
 
@@ -157,7 +157,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
   failed_when: false
@@ -172,7 +172,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
 
@@ -189,7 +189,7 @@
         ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
         -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
       run_once: true
-      with_items: "{{ play_hosts }}"
+      with_items: "{{ ansible_play_batch }}"
       when: test_flaky_network
       changed_when: false
     - ansible.builtin.set_fact:
@@ -210,7 +210,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
   failed_when: false
@@ -229,7 +229,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
   failed_when: false
@@ -251,7 +251,7 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false
   failed_when: false
@@ -267,6 +267,6 @@
     ansible.builtin.shell ssh -O exit {{ hostvars[item].ansible_host }}
     -o ControlPath=~/.ansible/cp/{{ hostvars[item].ansible_host }}-{{ hostvars[item].ansible_port }}-{{ hostvars[item].ansible_user }}
   run_once: true
-  with_items: "{{ play_hosts }}"
+  with_items: "{{ ansible_play_batch }}"
   when: test_flaky_network
   changed_when: false


### PR DESCRIPTION
Several changes are aggregated here:
With HamWAN relinquishing 44.24.240.0/20, we remove that from the SNMP access list.
Address some ansible deprecation issues
Update handling of SSH options and add documenation of SSH security changes and their impact on our access to older RouterOS versions and and possibly other down-rev devices via SSH.